### PR TITLE
feat: new identity technique

### DIFF
--- a/docs/api_reference/config.md
+++ b/docs/api_reference/config.md
@@ -20,7 +20,7 @@ method accepts a Python dictionary following the schema below.
 | `steps[i].method`         | `dict`              | Defines the anonymization technique and its parameters. |
 | `steps[i].method.type`    | `str`               | The name of the anonymization technique in snake_case.  |
 | `steps[i].method.<param>` | `dict`              | Additional key-value pairs for technique-specific parameters. See the [list](./techniques.md#techniques) of anonymization techniques and their respective parameters.    |
-| `steps[i].columns`        | `list[string] | None` | The list of column names to which the anonymization method applies. |
+| `steps[i].columns`        | `list[string] | None` | The list of column names to which the anonymization method applies. If set to None, the technique is applied to all columns. An empty list is not allowed. |
 
 For a full configuration example, see the code below.
 Note that some parameters may be mutually exclusive and are therefore not included in this example.  

--- a/docs/api_reference/techniques.md
+++ b/docs/api_reference/techniques.md
@@ -25,6 +25,8 @@ These techniques are implemented as classes that derive from
 
 ## Techniques
 
+::: aindo.anonymize.techniques.identity.Identity
+
 ::: aindo.anonymize.techniques.data_nulling.DataNulling
 
 ::: aindo.anonymize.techniques.char_masking.CharacterMasking

--- a/docs/get_started/overview.md
+++ b/docs/get_started/overview.md
@@ -13,6 +13,9 @@ or `pandas.Series` — based on the method used.
 
 It currently implements the following anonymization techniques:
 
+- [**Identity**][aindo.anonymize.techniques.identity.Identity]:
+leaves the original data untouched, useful in a declarative approach (see below).
+
 - [**Data nulling**][aindo.anonymize.techniques.data_nulling.DataNulling]:
 Replaces the original data with `None` or a custom constant value.
 

--- a/src/aindo/anonymize/config.py
+++ b/src/aindo/anonymize/config.py
@@ -10,6 +10,7 @@ from aindo.anonymize.techniques import (
     Binning,
     CharacterMasking,
     DataNulling,
+    Identity,
     KeyHashing,
     Mocking,
     PerturbationCategorical,
@@ -25,6 +26,7 @@ ALL_TECHNIQUES: list[Type] = [
     CharacterMasking,
     DataNulling,
     KeyHashing,
+    Identity,
     Mocking,
     PerturbationCategorical,
     PerturbationNumerical,
@@ -39,6 +41,7 @@ class TechniqueType(str, Enum):
     CHARACTER_MASKING = "character_masking"
     DATA_NULLING = "data_nulling"
     KEY_HASHING = "key_hashing"
+    IDENTITY = "identity"
     MOCKING = "mocking"
     PERTURBATION_CATEGORICAL = "perturbation_categorical"
     PERTURBATION_NUMERICAL = "perturbation_numerical"

--- a/src/aindo/anonymize/config.py
+++ b/src/aindo/anonymize/config.py
@@ -109,6 +109,8 @@ class TechniqueItem:
     Attributes:
         method: Parameters defining the technique's configuration.
         columns: Input data columns to which the technique will be applied.
+            If set to None, the technique is applied to all columns.
+            An empty list is not allowed and will raise an error.
     """
 
     method: TechniqueMethod
@@ -144,7 +146,10 @@ class TechniqueItem:
         method_kwargs: dict[str, Any] = method_data.copy()
         method_kwargs.pop("type")
         method: TechniqueMethod = method_class(**method_kwargs)
-        return cls(method=method, columns=value.get("columns"))
+        columns: list[str] | None = value.get("columns", None)
+        if columns == []:
+            raise ValueError("Invalid input: the columns list cannot be empty.")
+        return cls(method=method, columns=columns)
 
     def __repr__(self) -> str:
         return f"TechniqueItem(method={self.method!r},columns={self.columns!r})"

--- a/src/aindo/anonymize/techniques/__init__.py
+++ b/src/aindo/anonymize/techniques/__init__.py
@@ -6,6 +6,7 @@ from aindo.anonymize.techniques.binning import Binning
 from aindo.anonymize.techniques.char_masking import CharacterMasking
 from aindo.anonymize.techniques.data_nulling import DataNulling
 from aindo.anonymize.techniques.hashing import KeyHashing
+from aindo.anonymize.techniques.identity import Identity
 from aindo.anonymize.techniques.mocking import Mocking, MockingGeneratorMethods
 from aindo.anonymize.techniques.perturbation import PerturbationCategorical, PerturbationNumerical
 from aindo.anonymize.techniques.swapping import Swapping
@@ -16,6 +17,7 @@ __all__ = [
     "CharacterMasking",
     "DataNulling",
     "KeyHashing",
+    "Identity",
     "Mocking",
     "MockingGeneratorMethods",
     "PerturbationCategorical",

--- a/src/aindo/anonymize/techniques/base.py
+++ b/src/aindo/anonymize/techniques/base.py
@@ -11,7 +11,7 @@ import pandas as pd
 class BaseTechnique(ABC):
     """Abstract base class for all anonymization techniques."""
 
-    preserve_type: ClassVar[bool]
+    preserve_type: ClassVar[bool] = True
 
     @abstractmethod
     def anonymize(self, dataframe: pd.DataFrame) -> pd.DataFrame:
@@ -36,8 +36,6 @@ class BaseSingleColumnTechnique(BaseTechnique, ABC):
     Subclasses should implement the `anonymize_column` method,
     which defines the logic for anonymizing a single column.
     """
-
-    preserve_type: ClassVar[bool] = True
 
     @abstractmethod
     def _apply_to_col(self, col: pd.Series) -> pd.Series:

--- a/src/aindo/anonymize/techniques/identity.py
+++ b/src/aindo/anonymize/techniques/identity.py
@@ -1,0 +1,22 @@
+# SPDX-FileCopyrightText: 2025 Aindo SpA
+#
+# SPDX-License-Identifier: MIT
+
+
+import pandas as pd
+
+from aindo.anonymize.techniques.base import BaseTechnique
+
+
+class Identity(BaseTechnique):
+    """Identity technique.
+
+    Leaves the original data untouched.
+    This special technique is particularly useful in a declarative approach (see documentation).
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+
+    def anonymize(self, dataframe: pd.DataFrame) -> pd.DataFrame:
+        return dataframe.copy()

--- a/tests/anonymize/conftest.py
+++ b/tests/anonymize/conftest.py
@@ -81,3 +81,26 @@ def time_column() -> pd.Series:
     start_date: datetime = datetime(2025, 1, 1, tzinfo=timezone.utc)
     values: list[time] = [(start_date + timedelta(days=i)).time() for i in range(COL_SIZE)]
     return pd.Series(values)
+
+
+@pytest.fixture(scope=DEFAULT_SCOPE)
+def dataframe_all_types(
+    integer_column: pd.Series,
+    numerical_column: pd.Series,
+    categorical_column: pd.Series,
+    string_column: pd.Series,
+    datetime_column: pd.Series,
+    date_column: pd.Series,
+    time_column: pd.Series,
+) -> pd.DataFrame:
+    return pd.DataFrame(
+        {
+            "integer_column": integer_column,
+            "numerical_column": numerical_column,
+            "categorical_column": categorical_column,
+            "string_column": string_column,
+            "datetime_column": datetime_column,
+            "date_column": date_column,
+            "time_column": time_column,
+        }
+    )

--- a/tests/anonymize/data/full_config.json
+++ b/tests/anonymize/data/full_config.json
@@ -5,7 +5,7 @@
         "type": "binning",
         "bins": 10
       },
-      "columns": ["column_a"]
+      "columns": ["column_bin"]
     },
     {
       "method": {
@@ -14,14 +14,14 @@
         "symbol": "*",
         "starting_direction": "left"
       },
-      "columns": ["column_b"]
+      "columns": ["column_mask"]
     },
     {
       "method": {
         "type": "data_nulling",
         "constant_value": "BLANK"
       },
-      "columns": ["column_c"]
+      "columns": ["column_null"]
     },
     {
       "method": {
@@ -30,14 +30,20 @@
         "salt": "my salt",
         "hash_name": "sha256"
       },
-      "columns": ["column_d"]
+      "columns": ["column_key_hash"]
+    },
+    {
+      "method": {
+        "type": "identity"
+      },
+      "columns": ["column_id_1", "column_id_2"]
     },
     {
       "method": {
         "type": "mocking",
         "data_generator": "name"
       },
-      "columns": ["column_e"]
+      "columns": ["column_mock"]
     },
     {
       "method": {
@@ -50,7 +56,7 @@
         ],
         "seed": 42
       },
-      "columns": ["column_f"]
+      "columns": ["column_pert_cat"]
     },
     {
       "method": {
@@ -60,7 +66,7 @@
         "perturbation_range": [1, 10],
         "seed": 42
       },
-      "columns": ["column_g"]
+      "columns": ["column_per_num"]
     },
     {
       "method": {
@@ -68,7 +74,7 @@
         "alpha": 0.8,
         "seed": 42
       },
-      "columns": ["column_h"]
+      "columns": ["column_swap"]
     },
     {
       "method": {
@@ -76,14 +82,14 @@
         "q": 0.8,
         "other_label": "OTHER"
       },
-      "columns": ["column_i"]
+      "columns": ["column_tbc_cat"]
     },
     {
       "method": {
         "type": "top_bottom_coding_numerical",
         "q": 0.3
       },
-      "columns": ["column_l"]
+      "columns": ["column_tbc_num"]
     }
   ]
 }

--- a/tests/anonymize/techniques/test_identity.py
+++ b/tests/anonymize/techniques/test_identity.py
@@ -1,0 +1,15 @@
+# SPDX-FileCopyrightText: 2025 Aindo SpA
+#
+# SPDX-License-Identifier: MIT
+
+
+import pandas as pd
+
+from aindo.anonymize.techniques.identity import Identity
+
+
+def test_identity(dataframe_all_types: pd.DataFrame):
+    anonymizer = Identity()
+    out = anonymizer.anonymize(dataframe_all_types)
+
+    assert out.equals(dataframe_all_types)

--- a/tests/anonymize/test_config.py
+++ b/tests/anonymize/test_config.py
@@ -72,16 +72,17 @@ def test_spec_classes(
         ({}, "Invalid input: 'method'"),
         ({"method": {"constant_value": None}}, "Invalid input: 'method'"),
         ({"method": {"type": "wrong-type"}}, "Invalid input: unknown technique"),
+        ({"method": {"type": "identity"}, "columns": []}, "Invalid input: the columns list cannot be empty"),
     ],
-    ids=["missing-method", "missing-type", "unknown-technique"],
+    ids=["missing-method", "missing-type", "unknown-technique", "empty-columns-list"],
 )
 def test_techniqueitem_from_dict_error(value: dict[str, Any], expected_match: str):
     with pytest.raises(ValueError, match=expected_match):
-        TechniqueItem.from_dict({"name": "test name", "columns": [], **value})
+        TechniqueItem.from_dict(value)
 
 
 def test_techniqueitem_from_dict_ok():
-    t = TechniqueItem.from_dict({"name": "test name", "columns": [], "method": {"type": "binning", "bins": 1}})
+    t = TechniqueItem.from_dict({"columns": ["a"], "method": {"type": "binning", "bins": 1}})
     assert t and isinstance(t, TechniqueItem)
 
 

--- a/tests/anonymize/test_pipeline.py
+++ b/tests/anonymize/test_pipeline.py
@@ -99,7 +99,6 @@ def test_repetition():
     }
     workflow = AnonymizationPipeline(config=Config.from_dict(config_data))
     out = workflow.run(df)
-    print(out)
 
     assert out.integer_column.equals(pd.Series(["BL***", "BL***", "BL***"]))
 
@@ -109,7 +108,6 @@ def test_anonymize_all_dataframe():
     config_data: dict[str, Any] = {
         "steps": [
             {
-                "columns": [],
                 "method": {"type": "identity"},
             }
         ]

--- a/tests/anonymize/test_pipeline.py
+++ b/tests/anonymize/test_pipeline.py
@@ -15,12 +15,10 @@ EXAMPLE_CONFIG: Config = Config.from_dict(
     {
         "steps": [
             {
-                "name": "perturbation",
                 "columns": ["integer_column"],
                 "method": {"type": "perturbation_numerical", "alpha": 0.1, "seed": SEED},
             },
             {
-                "name": "hash",
                 "columns": ["string_column"],
                 "method": {"type": "key_hashing", "key": "secret key", "salt": "secret salt", "hash_name": "sha256"},
             },
@@ -29,7 +27,7 @@ EXAMPLE_CONFIG: Config = Config.from_dict(
 )
 
 
-def test_run(string_column: pd.Series, integer_column: pd.Series):
+def test_simple_run(string_column: pd.Series, integer_column: pd.Series):
     dataframe = pd.DataFrame({"string_column": string_column, "integer_column": integer_column})
     workflow = AnonymizationPipeline(EXAMPLE_CONFIG)
     out: pd.DataFrame = workflow.run(dataframe)
@@ -46,14 +44,12 @@ def test_run(string_column: pd.Series, integer_column: pd.Series):
     assert out["string_column"].equals(col_out)
 
 
-def test_run_check_copy():
-    # Verify that input columns not subject to anonymization remain unchanged
-    # and original dataframe is not modified.
+def test_check_copy():
+    # Verify that original dataframe is not modified.
     df = pd.DataFrame({"string_column": ["A", "B", "C"], "integer_column": [1, 2, 3]})
     config_data: dict[str, Any] = {
         "steps": [
             {
-                "name": "nulling",
                 "columns": ["integer_column"],
                 "method": {"type": "data_nulling", "constant_value": "BLANK"},
             }
@@ -65,5 +61,60 @@ def test_run_check_copy():
     assert df.string_column.equals(pd.Series(["A", "B", "C"]))
     assert df.integer_column.equals(pd.Series([1, 2, 3]))
 
-    assert out.string_column.equals(df.string_column)
     assert out.integer_column.equals(pd.Series(["BLANK" for _ in [1, 2, 3]]))
+
+
+def test_unused_cols():
+    df = pd.DataFrame({"string_column": ["A", "B", "C"], "integer_column": [1, 2, 3]})
+    config_data: dict[str, Any] = {
+        "steps": [
+            {
+                "columns": ["integer_column"],
+                "method": {"type": "data_nulling", "constant_value": "BLANK"},
+            }
+        ]
+    }
+    workflow = AnonymizationPipeline(config=Config.from_dict(config_data))
+    out = workflow.run(df)
+
+    assert out.columns.to_list() == ["integer_column"]
+
+
+def test_repetition():
+    # This test ensures that techniques are applied to previously anonymized columns.
+    # Normally, character masking cannot be applied to an integer column,
+    # but here, data nulling is applied first, transforming the type to string.
+    df = pd.DataFrame({"integer_column": [1, 2, 3]})
+    config_data: dict[str, Any] = {
+        "steps": [
+            {
+                "columns": ["integer_column"],
+                "method": {"type": "data_nulling", "constant_value": "BLANK"},
+            },
+            {
+                "columns": ["integer_column"],
+                "method": {"type": "character_masking", "mask_length": 3, "starting_direction": "right"},
+            },
+        ]
+    }
+    workflow = AnonymizationPipeline(config=Config.from_dict(config_data))
+    out = workflow.run(df)
+    print(out)
+
+    assert out.integer_column.equals(pd.Series(["BL***", "BL***", "BL***"]))
+
+
+def test_anonymize_all_dataframe():
+    df = pd.DataFrame({"string_column": ["A", "B", "C"], "integer_column": [1, 2, 3]})
+    config_data: dict[str, Any] = {
+        "steps": [
+            {
+                "columns": [],
+                "method": {"type": "identity"},
+            }
+        ]
+    }
+    workflow = AnonymizationPipeline(config=Config.from_dict(config_data))
+    out = workflow.run(df)
+
+    assert out.equals(df)


### PR DESCRIPTION
This PR introduces a new **Identity** technique that preserves the original input data.

With this addition, the declarative approach (see `AnonymizationPipeline`)  can now output only the anonymized columns specified in the configuration. The Identity technique is useful for retaining one or more columns in the resulting dataframe without modification.