### PR TITLE
ci: ensure documentation builds successfully on PRs and manual runs

### DIFF
--- a/.github/workflows/main-ci-flow.yml
+++ b/.github/workflows/main-ci-flow.yml
@@ -27,6 +27,25 @@ jobs:
       python-version: ${{ matrix.python-version }}
       skip-coverage: ${{ matrix.python-version != '3.10' }} # Run coverage analysis only once.
 
+  docs-build:
+    name: Build and verify docs
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event_name == 'pull_request' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout main branch
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+  
+      - name: Install requirements
+        run: pip install -r docs/requirements.txt
+        
+      - name: Build documentation
+        run: mkdocs build 
+
   docs-publish:
     name: Publish documentation for version 'dev'
     needs: [pre-commit, tests]


### PR DESCRIPTION
This PR enhances the main CI workflow by adding a job that builds the documentation on pull requests and manual triggers, ensuring it can be successfully generated.

For pushes, this job is skipped, as the build step is already handled by the `docs-publish` job.