### PR TITLE
build: lint docstrings

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,7 +20,7 @@ repos:
     args: [--contrib=CT1, --msg-filename]
   - id: gitlint-ci
 - repo: https://github.com/charliermarsh/ruff-pre-commit
-  rev: v0.9.2
+  rev: v0.11.5
   hooks:
     - id: ruff
       args: [--fix]

--- a/docs/developers/contributing.md
+++ b/docs/developers/contributing.md
@@ -106,11 +106,13 @@ balancing brevity with completeness to ensure all essential information is inclu
 Ensure that all code is well-documented using properly formatted docstrings.
 The following elements should include documentation:
 
+- Modules
 - Class definitions
 - Function definitions
 - Module-level variables
 
 **Aindo Anonymize** follows [Google-style docstrings](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings)
+formatted according to [PEP 257](https://www.python.org/dev/peps/pep-0257/) guidelines
 (see [Example Google Style Python Docstrings](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html)
 for further examples).  
 Class attributes and function arguments should be documented in the format `name: description.`,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ dev = [
   "pandas-stubs",
   # The following are also installed by pre-commit
   # Note: ensure these versions match those specified in the pre-commit configuration.
-  "ruff==0.9.2",
+  "ruff==0.11.5",
   "gitlint==0.19.1",
   "reuse==5.0.2",
 ]
@@ -66,11 +66,23 @@ version = { attr = "aindo.anonymize.version.__version__" }
 
 [tool.ruff]
 line-length = 120
-lint.pycodestyle.max-doc-length = 120
-lint.pycodestyle.max-line-length = 120
-lint.extend-select = ["TID252", "I"]
-lint.extend-safe-fixes = ["TID252"]
-lint.flake8-tidy-imports.ban-relative-imports = "all"
+
+[tool.ruff.lint]
+select = [
+  'I',      # isort
+  'D',      # pydocstyle
+  "TID252", # flake8-tidy-imports
+]
+ignore = ["D105", "D107"]
+pydocstyle.convention = "google"
+pycodestyle.max-doc-length = 120
+pycodestyle.max-line-length = 120
+extend-safe-fixes = ["TID252"]
+flake8-tidy-imports.ban-relative-imports = "all"
+
+[tool.ruff.lint.per-file-ignores]
+"docs/*" = ["D"]
+"tests/*" = ["D"]
 
 [tool.pyright]
 include = ["src/*"]

--- a/src/aindo/anonymize/__init__.py
+++ b/src/aindo/anonymize/__init__.py
@@ -2,6 +2,8 @@
 #
 # SPDX-License-Identifier: MIT
 
+"""A lightweight Python library for anonymizing tabular data."""
+
 from aindo.anonymize import version as aindo_version
 from aindo.anonymize.config import Config
 from aindo.anonymize.pipeline import AnonymizationPipeline

--- a/src/aindo/anonymize/config.py
+++ b/src/aindo/anonymize/config.py
@@ -2,6 +2,8 @@
 #
 # SPDX-License-Identifier: MIT
 
+"""Configuration for the high-level interface `aindo.anonymize.AnonymizationPipeline`."""
+
 import re
 from dataclasses import dataclass
 from enum import Enum
@@ -38,6 +40,8 @@ ALL_TECHNIQUES: list[type[BaseTechnique]] = [
 
 
 class TechniqueType(str, Enum):
+    """An enumeration of anonymization techniques."""
+
     BINNING = "binning"
     CHARACTER_MASKING = "character_masking"
     DATA_NULLING = "data_nulling"

--- a/src/aindo/anonymize/pipeline.py
+++ b/src/aindo/anonymize/pipeline.py
@@ -2,6 +2,8 @@
 #
 # SPDX-License-Identifier: MIT
 
+"""A high-level interface for orchestrating the anonymization process."""
+
 import itertools
 from typing import cast
 

--- a/src/aindo/anonymize/techniques/__init__.py
+++ b/src/aindo/anonymize/techniques/__init__.py
@@ -2,6 +2,8 @@
 #
 # SPDX-License-Identifier: MIT
 
+"""Implementation of all anonymization techniques."""
+
 from aindo.anonymize.techniques.binning import Binning
 from aindo.anonymize.techniques.char_masking import CharacterMasking
 from aindo.anonymize.techniques.data_nulling import DataNulling

--- a/src/aindo/anonymize/techniques/base.py
+++ b/src/aindo/anonymize/techniques/base.py
@@ -2,6 +2,8 @@
 #
 # SPDX-License-Identifier: MIT
 
+"""Base class implementations for anonymization techniques."""
+
 from abc import ABC, abstractmethod
 from typing import ClassVar
 

--- a/src/aindo/anonymize/techniques/binning.py
+++ b/src/aindo/anonymize/techniques/binning.py
@@ -2,6 +2,8 @@
 #
 # SPDX-License-Identifier: MIT
 
+"""Implementation of the binning technique."""
+
 from typing import ClassVar, Sequence
 
 import pandas as pd

--- a/src/aindo/anonymize/techniques/char_masking.py
+++ b/src/aindo/anonymize/techniques/char_masking.py
@@ -2,6 +2,8 @@
 #
 # SPDX-License-Identifier: MIT
 
+"""Implementation of the character masking technique."""
+
 from typing import AnyStr, ClassVar, Generic, Literal
 
 import pandas as pd

--- a/src/aindo/anonymize/techniques/common.py
+++ b/src/aindo/anonymize/techniques/common.py
@@ -2,6 +2,8 @@
 #
 # SPDX-License-Identifier: MIT
 
+"""Mixin class implementations."""
+
 from numpy.random import Generator, default_rng
 
 SeedT = int | Generator | None

--- a/src/aindo/anonymize/techniques/data_nulling.py
+++ b/src/aindo/anonymize/techniques/data_nulling.py
@@ -2,6 +2,8 @@
 #
 # SPDX-License-Identifier: MIT
 
+"""Implementation of the data nulling technique."""
+
 from typing import Any, ClassVar
 
 import pandas as pd

--- a/src/aindo/anonymize/techniques/hashing.py
+++ b/src/aindo/anonymize/techniques/hashing.py
@@ -2,6 +2,8 @@
 #
 # SPDX-License-Identifier: MIT
 
+"""Implementation of the hashing technique."""
+
 import hashlib
 import hmac
 import secrets
@@ -54,4 +56,9 @@ class KeyHashing(BaseSingleColumnTechnique):
 
     @classmethod
     def generate_salt(cls) -> str:
+        """Generates a random salt.
+
+        Returns:
+            str: A random salt.
+        """
         return secrets.token_hex(16)

--- a/src/aindo/anonymize/techniques/identity.py
+++ b/src/aindo/anonymize/techniques/identity.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: MIT
 
+"""Implementation of the identity technique."""
 
 import pandas as pd
 
@@ -19,4 +20,12 @@ class Identity(BaseTechnique):
         super().__init__()
 
     def anonymize(self, dataframe: pd.DataFrame) -> pd.DataFrame:
+        """Anonymize the input data using the identity technique.
+
+        Args:
+            dataframe: The input data to be anonymized.
+
+        Returns:
+            The anonymized version of the input data.
+        """
         return dataframe.copy()

--- a/src/aindo/anonymize/techniques/mocking.py
+++ b/src/aindo/anonymize/techniques/mocking.py
@@ -2,6 +2,8 @@
 #
 # SPDX-License-Identifier: MIT
 
+"""Implementation of the mocking technique."""
+
 from functools import partial
 from typing import Any, Callable, ClassVar, Literal
 
@@ -50,6 +52,7 @@ MockingGeneratorMethods = Literal[
     "user_agent","user_name","uuid4","windows_platform_token","word","words","year","zip","zipcode",
     "zipcode_in_state","zipcode_plus4",
 ]
+"""List all available generator methods from Faker (`fake`)."""
 # fmt: on
 
 
@@ -76,9 +79,11 @@ class Mocking(BaseSingleColumnTechnique):
         faker_kwargs: dict[str, Any] | None = None,
         faker_generator_kwargs: dict[str, Any] | None = None,
     ) -> None:
-        """
+        """Initializes the Mocking technique.
+
         Args:
             data_generator: Faker's generator method ("fake") used to generate data (e.g., name, email).
+            seed: A seed to initialize numpy `Generator`.
             faker_kwargs: Additional arguments passed to the main Faker object (proxy class).
             faker_generator_kwargs: Additional arguments passed to the Faker's generator method.
         """

--- a/src/aindo/anonymize/techniques/perturbation.py
+++ b/src/aindo/anonymize/techniques/perturbation.py
@@ -2,6 +2,8 @@
 #
 # SPDX-License-Identifier: MIT
 
+"""Implementation of the perturbation technique."""
+
 from __future__ import annotations
 
 from abc import ABC

--- a/src/aindo/anonymize/techniques/swapping.py
+++ b/src/aindo/anonymize/techniques/swapping.py
@@ -2,6 +2,8 @@
 #
 # SPDX-License-Identifier: MIT
 
+"""Implementation of the swapping technique."""
+
 import pandas as pd
 
 from aindo.anonymize.techniques.base import BaseSingleColumnTechnique

--- a/src/aindo/anonymize/techniques/top_bottom_coding.py
+++ b/src/aindo/anonymize/techniques/top_bottom_coding.py
@@ -2,6 +2,8 @@
 #
 # SPDX-License-Identifier: MIT
 
+"""Implementation of the top/bottom coding technique."""
+
 from typing import Any, ClassVar
 
 import pandas as pd

--- a/src/aindo/anonymize/version.py
+++ b/src/aindo/anonymize/version.py
@@ -2,4 +2,6 @@
 #
 # SPDX-License-Identifier: MIT
 
+"""The `version` module holds the version information for Aindo Anonymize."""
+
 __version__ = "1.1.0"


### PR DESCRIPTION
This change includes docstring checks in the linting process performed by Ruff.
It ensures that required docstrings are always present and follow Google-style formatting.