### PR TITLE
ci: allow manual triggering of the publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,6 +5,7 @@
 name: Publish release to PyPI and TestPyPI
 
 on:
+  workflow_dispatch:
   push:
     tags:
       - v[0-9]+.[0-9]+.[0-9]+
@@ -20,7 +21,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v3
       with:
-        python-version: "3.10"
+        python-version: '3.10'
         cache: 'pip'
 
     - name: Install 'build' library


### PR DESCRIPTION
Allow manual triggering of the workflow to publish the package to PyPI.