### PR TITLE
fix: data nulling dtype

### DIFF
--- a/src/aindo/anonymize/techniques/data_nulling.py
+++ b/src/aindo/anonymize/techniques/data_nulling.py
@@ -30,4 +30,4 @@ class DataNulling(BaseSingleColumnTechnique):
         self.constant_value = constant_value
 
     def _apply_to_col(self, col: pd.Series) -> pd.Series:
-        return pd.Series([self.constant_value for _ in col], dtype=type(self.constant_value))
+        return pd.Series([self.constant_value for _ in col])

--- a/tests/anonymize/techniques/test_data_nulling.py
+++ b/tests/anonymize/techniques/test_data_nulling.py
@@ -17,3 +17,11 @@ def test_data_nulling(column_type: str, request: pytest.FixtureRequest):
 
     assert column.size == out.size
     assert (out == "BLANK").all()
+
+
+def test_constant_is_none(integer_column: pd.Series):
+    anonymizer = DataNulling(constant_value=None)
+    out = anonymizer.anonymize_column(integer_column)
+
+    assert (out.isna()).all()
+    assert out.dtype == object


### PR DESCRIPTION
This PR fixes a bug in the Data Nulling technique that prevented the use of `None` for the `constant_value` parameter.
The issue was caused by an incorrect setting of the dtype parameter.