### PR TITLE
fix: handle missing values correctly

### DIFF
--- a/src/aindo/anonymize/techniques/char_masking.py
+++ b/src/aindo/anonymize/techniques/char_masking.py
@@ -61,4 +61,4 @@ class CharacterMasking(BaseSingleColumnTechnique, Generic[AnyStr]):
         return mask + value[self.mask_length :]
 
     def _apply_to_col(self, col: pd.Series) -> pd.Series:
-        return pd.Series([self._compute_mask(value) for value in col], dtype="str")
+        return pd.Series([self._compute_mask(value) if pd.notna(value) else value for value in col], dtype="str")

--- a/src/aindo/anonymize/techniques/data_nulling.py
+++ b/src/aindo/anonymize/techniques/data_nulling.py
@@ -14,8 +14,8 @@ from aindo.anonymize.techniques.base import BaseSingleColumnTechnique
 class DataNulling(BaseSingleColumnTechnique):
     """Implements data nulling.
 
-    Data nulling replaces the original data with a `None` value
-    (or a custom constant value).
+    Data nulling replaces the original data with a constant value.
+    Missing values (`np.NaN`, `None`, `pd.NA`, `pd.NaT`) are also replaced.
 
     Attributes:
         constant_value: The value that will replace the original data. Default to None.

--- a/src/aindo/anonymize/techniques/hashing.py
+++ b/src/aindo/anonymize/techniques/hashing.py
@@ -52,7 +52,7 @@ class KeyHashing(BaseSingleColumnTechnique):
         return b64encode(hmac_obj.digest()).decode()
 
     def _apply_to_col(self, col: pd.Series) -> pd.Series:
-        return pd.Series([self._compute_hash(value) for value in col], dtype="str")
+        return pd.Series([self._compute_hash(value) if pd.notna(value) else value for value in col], dtype="str")
 
     @classmethod
     def generate_salt(cls) -> str:

--- a/src/aindo/anonymize/techniques/mocking.py
+++ b/src/aindo/anonymize/techniques/mocking.py
@@ -62,6 +62,8 @@ class Mocking(BaseSingleColumnTechnique):
     Mocking generates realistic mock data for various fields such as names, addresses, emails, and more.
     It leverages the `faker` library to produce customizable, locale-aware fake data.
 
+    Missing values (`np.NaN`, `None`, `pd.NA`, `pd.NaT`) are replaced.
+
     Attributes:
         data_generator: Faker's generator method ("fake") used to generate data (e.g., name, email).
         seed: A seed to initialize numpy `Generator`.

--- a/src/aindo/anonymize/techniques/perturbation.py
+++ b/src/aindo/anonymize/techniques/perturbation.py
@@ -85,7 +85,7 @@ class PerturbationNumerical(BasePerturbation, Generic[NumericsT]):
 
             random_values: np.ndarray = self.generator.uniform(low=min_, high=max_, size=col.size)
             col_out: pd.Series = (1 - self.alpha) * col + self.alpha * random_values
-            return col_out.astype(col.dtype)
+            return col_out
 
 
 class PerturbationCategorical(BasePerturbation):
@@ -133,5 +133,7 @@ class PerturbationCategorical(BasePerturbation):
             np.array(list(frequencies.values())) if self.sampling_mode == "weighted" else None
         )
         rand_values = self.generator.choice(categories, size=col.size, p=probabilities)
+        mask: np.ndarray = col.notna().to_numpy()
+        mask &= self.generator.random(col.size) <= self.alpha
 
-        return pd.Series(np.where(self.generator.random() <= self.alpha, rand_values, col), dtype="category")
+        return pd.Series(np.where(mask, rand_values, col), dtype="category")

--- a/src/aindo/anonymize/techniques/top_bottom_coding.py
+++ b/src/aindo/anonymize/techniques/top_bottom_coding.py
@@ -6,6 +6,7 @@
 
 from typing import Any, ClassVar
 
+import numpy as np
 import pandas as pd
 
 from aindo.anonymize.techniques.base import BaseSingleColumnTechnique
@@ -116,4 +117,6 @@ class TopBottomCodingCategorical(BaseSingleColumnTechnique):
         out = out.cat.remove_categories(rare_categories)
         out = out.cat.add_categories(self.other_label)
         out.fillna(self.other_label, inplace=True)
+        out[col.isna()] = np.nan
+
         return out

--- a/tests/anonymize/techniques/test_binning.py
+++ b/tests/anonymize/techniques/test_binning.py
@@ -7,6 +7,7 @@ from datetime import datetime, timezone
 import pandas as pd
 
 from aindo.anonymize.techniques.binning import Binning
+from tests.anonymize.utils import assert_missing_values, insert_missing_values
 
 
 def test_binning_out_type(integer_column: pd.Series):
@@ -59,3 +60,11 @@ def test_binning_datetime(datetime_column):
 
     assert datetime_column.size == out.size
     assert (out.cat.categories == categories).all()
+
+
+def test_with_missing_values(integer_column: pd.Series):
+    anonymizer = Binning(bins=[0, 12, 20, 30])
+    input = insert_missing_values(integer_column)
+    out = anonymizer.anonymize_column(input)
+
+    assert_missing_values(out, preserved=True)

--- a/tests/anonymize/techniques/test_char_masking.py
+++ b/tests/anonymize/techniques/test_char_masking.py
@@ -8,6 +8,7 @@ import pandas as pd
 import pytest
 
 from aindo.anonymize.techniques.char_masking import CharacterMasking, StartingDirection
+from tests.anonymize.utils import assert_missing_values, insert_missing_values
 
 
 @pytest.mark.parametrize("column_name", ["string_column", "categorical_column"])
@@ -70,3 +71,11 @@ def test_masking_symbol(string_column: pd.Series):
     assert string_column.size == out.size
     for _, value in out.items():
         assert value[0] == symbol
+
+
+def test_with_missing_values(string_column: pd.Series):
+    anonymizer = CharacterMasking[str]()
+    input = insert_missing_values(string_column)
+    out: pd.Series = anonymizer.anonymize_column(input)
+
+    assert_missing_values(out, preserved=True)

--- a/tests/anonymize/techniques/test_data_nulling.py
+++ b/tests/anonymize/techniques/test_data_nulling.py
@@ -7,6 +7,7 @@ import pytest
 
 from aindo.anonymize.techniques.data_nulling import DataNulling
 from tests.anonymize.conftest import COLUMN_NAMES
+from tests.anonymize.utils import assert_missing_values, insert_missing_values
 
 
 @pytest.mark.parametrize("column_type", COLUMN_NAMES)
@@ -25,3 +26,11 @@ def test_constant_is_none(integer_column: pd.Series):
 
     assert (out.isna()).all()
     assert out.dtype == object
+
+
+def test_with_missing_values(string_column: pd.Series):
+    anonymizer = DataNulling(constant_value="BLANK")
+    input = insert_missing_values(string_column)
+    out: pd.Series = anonymizer.anonymize_column(input)
+
+    assert_missing_values(out, preserved=False)

--- a/tests/anonymize/techniques/test_hashing.py
+++ b/tests/anonymize/techniques/test_hashing.py
@@ -14,6 +14,7 @@ from tests.anonymize.conftest import COLUMN_NAMES
 SECRET_KEY: Literal["secret"] = "secret"
 SALT: Literal["salt"] = "salt"
 HASH_PATTERN: re.Pattern = re.compile(r"^[-A-Za-z0-9+/]*={0,3}$")
+from tests.anonymize.utils import assert_missing_values, insert_missing_values
 
 
 def wrong_hash_name():
@@ -43,3 +44,11 @@ def test_hashing(column_type: str, request: pytest.FixtureRequest):
 
     assert column.size == out.size
     assert out.apply(lambda x: bool(HASH_PATTERN.match(x))).all()
+
+
+def test_with_missing_values(string_column: pd.Series):
+    anonymizer = KeyHashing(key=SECRET_KEY, salt=SALT)
+    input = insert_missing_values(string_column)
+    out: pd.Series = anonymizer.anonymize_column(input)
+
+    assert_missing_values(out, preserved=True)

--- a/tests/anonymize/techniques/test_mocking.py
+++ b/tests/anonymize/techniques/test_mocking.py
@@ -10,6 +10,7 @@ from faker import Faker
 
 from aindo.anonymize.techniques.mocking import Mocking, MockingGeneratorMethods
 from tests.anonymize.conftest import SEED
+from tests.anonymize.utils import assert_missing_values, insert_missing_values
 
 
 def test_mocking_wrong_param():
@@ -53,3 +54,11 @@ def test_faker_generator_methods():
     for method_name in methods:
         method = getattr(fake, method_name, None)
         assert method is not None
+
+
+def test_with_missing_values(string_column: pd.Series):
+    anonymizer = Mocking(data_generator="name")
+    input = insert_missing_values(string_column)
+    out: pd.Series = anonymizer.anonymize_column(input)
+
+    assert_missing_values(out, preserved=False)

--- a/tests/anonymize/techniques/test_swapping.py
+++ b/tests/anonymize/techniques/test_swapping.py
@@ -8,6 +8,7 @@ import pytest
 
 from aindo.anonymize.techniques.swapping import Swapping
 from tests.anonymize.conftest import COLUMN_NAMES
+from tests.anonymize.utils import insert_missing_values
 
 
 def test_has_random_generator():
@@ -30,3 +31,12 @@ def test_full_swapping(rng: np.random.Generator, column_type: str, request: pyte
 
     assert out.size == column.size
     assert set(out) == set(column)
+
+
+def test_with_missing_values(rng: np.random.Generator, numerical_column: pd.Series):
+    anonymizer = Swapping(alpha=1, seed=rng)
+    input = insert_missing_values(numerical_column)
+    out: pd.Series = anonymizer.anonymize_column(input)
+
+    # Missing values are still present, but their positions have changed
+    assert sum(out.isna()) == 2

--- a/tests/anonymize/techniques/test_top_bottom_coding.py
+++ b/tests/anonymize/techniques/test_top_bottom_coding.py
@@ -8,6 +8,7 @@ import pandas as pd
 import pytest
 
 from aindo.anonymize.techniques.top_bottom_coding import TopBottomCodingCategorical, TopBottomCodingNumerical
+from tests.anonymize.utils import assert_missing_values, insert_missing_values
 
 
 class TestTopBottomCodingNumerical:
@@ -59,6 +60,13 @@ class TestTopBottomCodingNumerical:
 
         median: float = integer_column.median()
         assert (out == median).all()
+
+    def test_with_missing_values(self, numerical_column: pd.Series):
+        anonymizer = TopBottomCodingNumerical(1)
+        input = insert_missing_values(numerical_column)
+        out = anonymizer.anonymize_column(input)
+
+        assert_missing_values(out, preserved=True)
 
 
 class TestTopBottomCodingCategorical:
@@ -118,3 +126,10 @@ class TestTopBottomCodingCategorical:
         assert len(out.cat.categories) == 1
         assert out.cat.categories[0] == TopBottomCodingCategorical.other_label
         assert (out.values == TopBottomCodingCategorical.other_label).all()
+
+    def test_with_missing_values(self, categorical_column: pd.Series):
+        anonymizer = TopBottomCodingCategorical(1)
+        input = insert_missing_values(categorical_column)
+        out = anonymizer.anonymize_column(input)
+
+        assert_missing_values(out, preserved=True)

--- a/tests/anonymize/utils.py
+++ b/tests/anonymize/utils.py
@@ -4,6 +4,7 @@
 
 import os
 
+import numpy as np
 import pandas as pd
 from numpy.typing import ArrayLike
 from scipy.stats import chisquare, ks_2samp
@@ -44,3 +45,22 @@ def file_data_path(*path: str) -> str:
             *path,
         )
     )
+
+
+def insert_missing_values(sr: pd.Series) -> pd.Series:
+    """Returns the input Series with the first and last values as NaN."""
+    out = sr.copy()
+    out.iat[0] = np.nan
+    out.iat[-1] = np.nan
+    return out
+
+
+def assert_missing_values(sr: pd.Series, preserved: bool) -> None:
+    """Assert that missing values are either preserved or overwritten (i.e., no longer present).
+
+    Intended for use in conjunction with `insert_missing_values`.
+    """
+    if preserved:
+        assert pd.isna(sr.iat[0]) and pd.isna(sr.iat[-1])
+    else:
+        assert all(sr.notna())


### PR DESCRIPTION
This PR fixes a bug that occurred with certain techniques (e.g., character masking and hashing) when the input data contained missing values (`np.NaN`, `None`, `pd.NA`, `pd.NaT`).

It also clarifies how each technique handles missing values:
- in general, missing values are preserved;
- some techniques that implement value overriding - currently Data Nulling and Mocking -  replace missing values.