### PR TITLE
ci: disable Python cache in publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,13 +16,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Set up Python
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v5
       with:
         python-version: '3.10'
-        cache: 'pip'
 
     - name: Install 'build' library
       run: |


### PR DESCRIPTION
This PR disables the Python cache in the GitHub workflow that publishes the library to PyPI.
The cache has occasionally failed, which in turn has caused the entire publish workflow to fail.