### PR TITLE
fix: multiple bugs

### DIFF
--- a/src/aindo/anonymize/pipeline.py
+++ b/src/aindo/anonymize/pipeline.py
@@ -51,14 +51,15 @@ class AnonymizationPipeline:
 
             for step in self.config.steps:
                 method: BaseSpec = step.method
-                if step.columns:
-                    anonymized: pd.DataFrame = method.anonymize(result.loc[:, step.columns])
-                    if not method.preserve_type:
-                        for col_name, dtype in anonymized.dtypes.to_dict().items():
-                            result[col_name] = result[col_name].astype(dtype)
-                    result.loc[:, step.columns] = anonymized
-
-                else:
+                if step.columns is None:
                     result = method.anonymize(result)
+                    continue
+
+                anonymized: pd.DataFrame = method.anonymize(result.loc[:, step.columns])
+                if method.preserve_type:
+                    result.loc[:, step.columns] = anonymized
+                else:
+                    for col_name in step.columns:
+                        result[col_name] = anonymized[col_name]
 
             return result

--- a/src/aindo/anonymize/techniques/perturbation.py
+++ b/src/aindo/anonymize/techniques/perturbation.py
@@ -140,7 +140,6 @@ class PerturbationCategorical(BasePerturbation):
             np.array(list(frequencies.values())) if self.sampling_mode == "weighted" else None
         )
         rand_values = self.generator.choice(categories, size=col.size, p=probabilities)
-        mask: np.ndarray = col.notna().to_numpy()
-        mask &= self.generator.random(col.size) <= self.alpha
+        mask: np.ndarray = col.notna().to_numpy() & (self.generator.random(col.size) <= self.alpha)
 
         return pd.Series(np.where(mask, rand_values, col), dtype="category")

--- a/src/aindo/anonymize/techniques/top_bottom_coding.py
+++ b/src/aindo/anonymize/techniques/top_bottom_coding.py
@@ -56,8 +56,12 @@ class TopBottomCodingNumerical(BaseSingleColumnTechnique):
             upper_value = self.upper_value
         else:
             assert self.q is not None
-            lower_value = col.quantile(self.q / 2) if self.lower_value is None else self.lower_value
-            upper_value = col.quantile(1 - self.q / 2) if self.upper_value is None else self.upper_value
+            lower_value = (
+                col.quantile(self.q / 2, interpolation="nearest") if self.lower_value is None else self.lower_value
+            )
+            upper_value = (
+                col.quantile(1 - self.q / 2, interpolation="nearest") if self.upper_value is None else self.upper_value
+            )
 
         return col.clip(lower=lower_value, upper=upper_value)
 

--- a/tests/anonymize/conftest.py
+++ b/tests/anonymize/conftest.py
@@ -13,7 +13,7 @@ from faker import Faker
 DEFAULT_SCOPE: Literal["session"] = "session"
 SEED: Literal[12345] = 12345
 COL_SIZE: Literal[100] = 100
-INT_TYPE: type = np.int64
+INT_TYPE: pd.Int64Dtype = pd.Int64Dtype()
 FLOAT_TYPE: type = np.float64
 COLUMN_NAMES: list[str] = ["integer", "numerical", "categorical", "string", "date", "datetime", "time"]
 

--- a/tests/anonymize/techniques/test_perturbation.py
+++ b/tests/anonymize/techniques/test_perturbation.py
@@ -10,7 +10,7 @@ import pytest
 from scipy import stats
 
 from aindo.anonymize.techniques.perturbation import PerturbationCategorical, PerturbationNumerical, SamplingMode
-from tests.anonymize.conftest import FLOAT_TYPE, INT_TYPE
+from tests.anonymize.conftest import FLOAT_TYPE
 from tests.anonymize.utils import (
     assert_categorical_distribution,
     assert_missing_values,
@@ -29,11 +29,11 @@ class TestPerturbationNumerical:
     @pytest.mark.parametrize("column_name", ["integer_column", "numerical_column"])
     def test_out_type(self, rng: np.random.Generator, column_name: str, request: pytest.FixtureRequest):
         column: pd.Series = request.getfixturevalue(column_name)
-        _type = FLOAT_TYPE if column_name.startswith("numerical") else INT_TYPE
+        _type = float if column_name.startswith("numerical") else int
         anonymizer = PerturbationNumerical[_type](alpha=1, seed=rng)
         out = anonymizer.anonymize_column(column)
 
-        assert out.dtype == column.dtype == _type
+        assert out.dtype == column.dtype
 
     @pytest.mark.parametrize(
         "sampling_mode",
@@ -51,7 +51,7 @@ class TestPerturbationNumerical:
         self, rng: np.random.Generator, column_name: str, request: pytest.FixtureRequest
     ):
         column: pd.Series = request.getfixturevalue(column_name)
-        _type = FLOAT_TYPE if column_name.startswith("numerical") else INT_TYPE
+        _type = float if column_name.startswith("numerical") else int
         anonymizer = PerturbationNumerical[_type](alpha=1, sampling_mode="uniform", seed=rng)
         out = anonymizer.anonymize_column(column)
 

--- a/tests/anonymize/techniques/test_top_bottom_coding.py
+++ b/tests/anonymize/techniques/test_top_bottom_coding.py
@@ -37,6 +37,14 @@ class TestTopBottomCodingNumerical:
         with pytest.raises(ValueError, match=error_message):
             TopBottomCodingNumerical(**params)
 
+    @pytest.mark.parametrize("column_name", ["integer_column"])
+    def test_out_type(self, column_name: str, request: pytest.FixtureRequest):
+        column: pd.Series = request.getfixturevalue(column_name)
+        anonymizer = TopBottomCodingNumerical(self.q)
+        out = anonymizer.anonymize_column(column)
+
+        assert out.dtype == column.dtype
+
     @pytest.mark.parametrize("column_name", ["integer_column", "numerical_column"])
     def test_replacing(self, column_name: str, request: pytest.FixtureRequest):
         column: pd.Series = request.getfixturevalue(column_name)


### PR DESCRIPTION
#### Casting Issue in `AnonymizationPipeline`

The `AnonymizationPipeline` performed type conversion using `pandas.Series.astype` when a technique changed the output type. However, this caused errors for certain type conversions.

#### Read-Only array handling in Perturbation (categorical) 

The perturbation technique for categorical columns used boolean masks to handle missing values and perturbation intensity. In some cases, `numpy.bitwise_and` raised a read-only array error.

#### Quantile computation in Top/Bottom Coding (numerical)

Quantile computation always returned a float, which led to errors when calling `pandas.Series.clip` on columns with `pandas.Int64Dtype`.

