### PR TITLE
Refactor release and publish action

### DIFF
--- a/.github/actions/build-library/action.yaml
+++ b/.github/actions/build-library/action.yaml
@@ -1,0 +1,28 @@
+# SPDX-FileCopyrightText: 2026 Aindo SpA
+#
+# SPDX-License-Identifier: MIT
+
+name: 'Build'
+description: 'Build aindo-anonymize library and upload artifact'
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.10'
+
+    - name: Install 'build' library
+      run: |
+        python -m pip install --upgrade pip
+        pip install build
+
+    - name: Build library
+      run: python -m build
+
+    - name: Store the distribution packages
+      uses: actions/upload-artifact@v4
+      with:
+        name: python-package-distributions
+        path: dist/

--- a/.github/actions/publish/action.yaml
+++ b/.github/actions/publish/action.yaml
@@ -1,0 +1,25 @@
+# SPDX-FileCopyrightText: 2026 Aindo SpA
+#
+# SPDX-License-Identifier: MIT
+
+name: 'Publish'
+description: 'Publish aindo-anonymize library to a PyPI compatible repository'
+
+inputs:
+  repository-url:
+    description: 'Repository url to use'
+    required: false
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Download all the distributions
+      uses: actions/download-artifact@v4
+      with:
+        name: python-package-distributions
+        path: dist/
+
+    - name: Publish package to TestPyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        repository-url: ${{ inputs.repository-url }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,77 +6,39 @@ name: Publish release to PyPI and TestPyPI
 
 on:
   workflow_dispatch:
-  push:
-    tags:
-      - v[0-9]+.[0-9]+.[0-9]+
 
 jobs:
   build:
     name: Build distribution package
     runs-on: ubuntu-latest
-
     steps:
-    - uses: actions/checkout@v4
-
-    - name: Set up Python
-      uses: actions/setup-python@v5
-      with:
-        python-version: '3.10'
-
-    - name: Install 'build' library
-      run: |
-        python -m pip install --upgrade pip
-        pip install build
-
-    - name: Build library
-      run: python -m build
-
-    - name: Store the distribution packages
-      uses: actions/upload-artifact@v4
-      with:
-        name: python-package-distributions
-        path: dist/
+    - name: Checkout repo
+      uses: actions/checkout@v7
+    - name: Build
+      uses: ./.github/actions/build-library
 
   publish-to-testpypi:
     runs-on: ubuntu-latest
     needs: [build]
-
     environment:
       name: testpypi
       url: https://test.pypi.org/p/aindo-anonymize
-    
     permissions:
       id-token: write
-
     steps:
-    - name: Download all the distributions
-      uses: actions/download-artifact@v4
-      with:
-        name: python-package-distributions
-        path: dist/
-
     - name: Publish package to TestPyPI
-      uses: pypa/gh-action-pypi-publish@release/v1
+      uses: ./.github/actions/publish
       with:
         repository-url: https://test.pypi.org/legacy/
 
   publish-to-pypi:
     runs-on: ubuntu-latest
     needs: [build, publish-to-testpypi]
-    
     environment:
       name: pypi
       url: https://pypi.org/p/aindo-anonymize
-    
     permissions:
       id-token: write
-
     steps:
-    - name: Download all the distributions
-      uses: actions/download-artifact@v4
-      with:
-        name: python-package-distributions
-        path: dist/
-
     - name: Publish package to PyPI
-      uses: pypa/gh-action-pypi-publish@release/v1
+      uses: ./.github/actions/publish

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,8 +18,61 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
+    outputs:
+      releases_created: ${{ steps.release.outputs.releases_created }}
+      tag_name: ${{ steps.release.outputs.tag_name }}
+      version: ${{ steps.release.outputs.version }}
     steps:
-    - uses: googleapis/release-please-action@v4
+    - uses: googleapis/release-please-action@v5
       with:
-        token: ${{ secrets.PAT_TOKEN }}
         release-type: python
+
+  debug:
+    name: Debug
+    needs: [release]
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          echo "Debug:"
+          echo "Release created: ${{ needs.release.outputs.releases_created }}"
+          echo "Tag name: ${{ needs.release.outputs.tag_name }}"
+          echo "Version: ${{ needs.release.outputs.version }}"
+
+  build:
+    name: Build distribution package
+    runs-on: ubuntu-latest
+    needs: [release]
+    if: needs.release.outputs.releases_created
+    steps:
+    - name: Checkout release ${{ needs.release.outputs.tag_name }}
+      uses: actions/checkout@v7
+      with:
+        ref: '${{ needs.release.outputs.tag_name }}'
+    - name: Build
+      uses: ./.github/actions/build-library
+
+  publish-to-testpypi:
+    runs-on: ubuntu-latest
+    needs: [build]
+    environment:
+      name: testpypi
+      url: https://test.pypi.org/p/aindo-anonymize
+    permissions:
+      id-token: write
+    steps:
+    - name: Publish package to TestPyPI
+      uses: ./.github/actions/publish
+      with:
+        repository-url: https://test.pypi.org/legacy/
+
+  publish-to-pypi:
+    runs-on: ubuntu-latest
+    needs: [build, publish-to-testpypi]
+    environment:
+      name: pypi
+      url: https://pypi.org/p/aindo-anonymize
+    permissions:
+      id-token: write
+    steps:
+    - name: Publish package to PyPI
+      uses: ./.github/actions/publish


### PR DESCRIPTION
The pipeline is failing because of an issue with mkdocs, first look at: #27.

Remove the need to use a custom github PAT token, by running the publish code in the same action (but different job). Also the build-library and publish functionality was split into composite actions, that are reused from the `publish.yml` ci pipelines (which is only a manual trigger).