### PR TITLE
docs: mkdocstrings import has been renamed to inventories

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -127,7 +127,7 @@ plugins:
             signature_crossrefs: true
             filters: ["!^_"]
             modernize_annotations: true
-          import:
+          inventories:
             - url: https://docs.python.org/3/objects.inv
               domains: [py, std]           
             - url: https://pandas.pydata.org/pandas-docs/stable/objects.inv


### PR DESCRIPTION
At the moment the main CI workflow fails with:
```
Traceback (most recent call last):
...
TypeError: PythonConfig.__init__() got an unexpected keyword argument 'import'
```
because the `import` key wa replace with `inventories`.

[Main CI flow, failing job](https://github.com/aindo-com/aindo-anonymize/actions/runs/30281193026/job/90027725775)